### PR TITLE
feat: revamp chillpickle.org as ChillPickle organization site

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,3 @@
+[allowlist]
+  description = "Historical pre-signed S3 URL (expired Aug 2024, 5-min TTL STS token)"
+  commits = ["e63a924aadccbb587f18da2b185c99826369c602"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev       # start Vite dev server
+npm run build     # production build to dist/
+npm run preview   # serve production build locally
+npm run lint      # ESLint (src/ only)
+```
+
+No test framework is configured. Use `npm run build` as baseline validation; test CV generation manually with the "Download CV" button in the browser.
+
+## Architecture
+
+Single-page Svelte 5 + Vite app deployed on Vercel. Two pages (`news`, `aboutme`) controlled by `activeTab` state in `App.svelte`, which also owns global body styles and the nebula background overlay.
+
+```
+src/
+  main.js              # mounts App
+  App.svelte           # root shell — Sidebar + tab-switched content area
+  CV.svelte            # CV layout rendered into a hidden DOM node for PDF export
+  cvData.js            # all CV content as structured JS objects
+  components/
+    Sidebar.svelte     # fixed 220px nav, drives activeTab via bind:
+    Starfield.svelte   # canvas starfield background
+    TerminalBoot.svelte
+    GameOfLife.svelte
+    MotivationSection.svelte
+    HangingScroll.svelte
+    TechStack.svelte
+  pages/
+    AboutMe.svelte     # profile, bio, tech stack, decorative components; owns PDF download logic
+    News.svelte        # placeholder terminal-style feed
+```
+
+**CV PDF generation** (`AboutMe.svelte → downloadCV`): Svelte `mount()` renders `CV.svelte` into a hidden off-screen `<div>`, html2pdf.js captures it, then `unmount()` tears it down. CV content lives exclusively in `src/cvData.js`.
+
+## Styling
+
+- Global body/reset styles live in `App.svelte`'s `:global()` blocks — not in `public/global.css`.
+- Component-scoped `<style>` blocks for everything else.
+- Design system: dark universe theme (`#030308` background, `#a78bfa` purple accent, `#fbbf24` gold, `#f472b6` pink). Fonts: Inter (body) + JetBrains Mono (monospace/labels), both loaded via Google Fonts in `index.html`.
+- CSS utility library: `tenoxui` (available but usage is minimal).
+
+## CI/CD
+
+Three GitHub Actions workflows on push/PR to `main`:
+- **CI** (`ci.yml`): build + `npm audit --audit-level=high` + ESLint
+- **CodeQL** (`codeql.yml`): SAST on JS/TS, also runs weekly
+- **Dependency Review** (`dependency-review.yml`): blocks PRs with high-severity new deps
+
+## Commit Style
+
+Conventional Commits: `feat:`, `fix:`, `chore:` prefixes. Keep messages short and imperative.

--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>chill pickle</title>
+    <title>ChillPickle — Building things that actually work</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Noto+Serif+SC:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/public/cv/download/index.html
+++ b/public/cv/download/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="refresh" content="0;url=/qitpy/cv/QuyetDoan_DevOps_Jan2026.pdf">
+  <meta http-equiv="refresh" content="0;url=/cv/QuyetDoan_DevOps_Jan2026.pdf">
   <title>Downloading CV...</title>
 </head>
 <body>
-  <p>Downloading CV... If it doesn't start, <a href="/qitpy/cv/QuyetDoan_DevOps_Jan2026.pdf">click here</a>.</p>
+  <p>Downloading CV... If it doesn't start, <a href="/cv/QuyetDoan_DevOps_Jan2026.pdf">click here</a>.</p>
 </body>
 </html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,10 +2,13 @@
 <script>
   import Sidebar from './components/Sidebar.svelte';
   import Starfield from './components/Starfield.svelte';
-  import News from './pages/News.svelte';
-  import AboutMe from './pages/AboutMe.svelte';
+  import Home from './pages/Home.svelte';
+  import Work from './pages/Work.svelte';
+  import Services from './pages/Services.svelte';
+  import Team from './pages/Team.svelte';
+  import Blog from './pages/Blog.svelte';
 
-  let activeTab = 'news';
+  let activeTab = 'home';
 </script>
 
 <style>
@@ -71,10 +74,16 @@
   <Sidebar bind:activeTab />
 
   <div class="content-area">
-    {#if activeTab === 'news'}
-      <News />
-    {:else if activeTab === 'aboutme'}
-      <AboutMe />
+    {#if activeTab === 'home'}
+      <Home onNavigate={(id) => { activeTab = id; }} />
+    {:else if activeTab === 'work'}
+      <Work />
+    {:else if activeTab === 'services'}
+      <Services />
+    {:else if activeTab === 'team'}
+      <Team />
+    {:else if activeTab === 'blog'}
+      <Blog />
     {/if}
   </div>
 </div>

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -1,10 +1,14 @@
 <script>
-  export let activeTab = 'news';
+  export let activeTab = 'home';
 
   let mobileOpen = false;
 
   const tabs = [
-    { id: 'news', label: 'News', icon: '📰' },
+    { id: 'home',     label: 'Home',       icon: '🏠' },
+    { id: 'work',     label: 'Work',       icon: '⚒️' },
+    { id: 'services', label: 'Services',   icon: '📦' },
+    { id: 'team',     label: 'Team',       icon: '👥' },
+    { id: 'blog',     label: 'Blog & Lab', icon: '📓' },
   ];
 
   function selectTab(id) {
@@ -139,36 +143,6 @@
     gap: 0.75rem;
   }
 
-  .footer-icon-btn {
-    background: none;
-    border: 1px solid rgba(167, 139, 250, 0.2);
-    border-radius: 4px;
-    color: #9d8ec4;
-    font-size: 1rem;
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    padding: 0;
-    flex-shrink: 0;
-  }
-
-  .footer-icon-btn:hover {
-    color: #c0c8e8;
-    border-color: rgba(167, 139, 250, 0.4);
-    background: rgba(167, 139, 250, 0.06);
-  }
-
-  .footer-icon-btn.active {
-    color: #a78bfa;
-    border-color: #a78bfa;
-    background: rgba(167, 139, 250, 0.08);
-    box-shadow: 0 0 8px rgba(167, 139, 250, 0.25);
-  }
-
   /* ── Mobile overlay backdrop ── */
   .backdrop {
     display: none;
@@ -210,7 +184,7 @@
 
 <aside class="sidebar" class:open={mobileOpen}>
   <div class="sidebar-logo">
-    <button class="pickle-icon" on:click={() => selectTab('news')} title="Home">🥒</button>
+    <button class="pickle-icon" on:click={() => selectTab('home')} title="Home">🥒</button>
   </div>
 
   <nav>
@@ -227,12 +201,6 @@
   </nav>
 
   <div class="sidebar-footer">
-    <button
-      class="footer-icon-btn"
-      class:active={activeTab === 'aboutme'}
-      on:click={() => selectTab('aboutme')}
-      title="About Me"
-    >👤</button>
-    <span>v0.1.0</span>
+    <span>v0.2.0</span>
   </div>
 </aside>

--- a/src/data/boot.js
+++ b/src/data/boot.js
@@ -1,7 +1,7 @@
 export const bootSequence = [
-  '[hIE] Initializing...',
-  '[hIE] Behavioral model loaded...',
-  '[hIE] Owner registration: confirmed',
+  '[ChillPickle] Initializing...',
+  '[ChillPickle] Systems online.',
+  '[ChillPickle] Ready to build.',
   'ACCESS GRANTED — Welcome, visitor.',
   '> _ <',
 ];

--- a/src/orgData.js
+++ b/src/orgData.js
@@ -1,0 +1,177 @@
+export const org = {
+  name: 'ChillPickle',
+  tagline: 'Building things that actually work.',
+  domain: 'chillpickle.org',
+  email: 'hello@chillpickle.org',
+  github: 'https://github.com/quniv',
+  version: 'v0.2.0',
+};
+
+export const missions = [
+  {
+    id: 'human-tech',
+    icon: '🤝',
+    title: 'Human + Technology',
+    body: 'We join hands to build open-source tools and applications that solve real problems in normal life — not just enterprise pipelines.',
+  },
+  {
+    id: 'lab',
+    icon: '🔬',
+    title: 'Technology Lab',
+    body: 'A laboratory for researchers and doers. We experiment with technology that transforms how people work, learn, and build.',
+  },
+  {
+    id: 'doers',
+    icon: '⚙️',
+    title: 'Small Team. Real Delivery.',
+    body: 'A tight group of engineers who work hard, price fairly, and build things that ship. Reputation earned through work, not slides.',
+  },
+];
+
+export const team = [
+  {
+    id: 'quyet-doan',
+    name: 'Quyet Doan',
+    role: 'DevSecOps Engineer',
+    avatar: 'images/avatar_022025.jpeg',
+    bio: 'Nearly 5 years in technology, 3 focused on cloud infrastructure and delivery. Started as a software developer — still thinks like one. AWS-primary, with hands-on Azure and GCP. Built CI/CD for 10+ projects, hardened cloud environments, and integrated AI-assisted workflows into operational automation.',
+    skills: ['AWS', 'Kubernetes', 'Terraform', 'GitHub Actions', 'Python', 'Security'],
+    links: {
+      github: 'https://github.com/qitpydev',
+      linkedin: 'https://www.linkedin.com/in/qitpy',
+    },
+  },
+];
+
+export const projects = [
+  {
+    id: 'chillpickle-org',
+    title: 'chillpickle.org',
+    tag: 'Open Source',
+    tagColor: 'green',
+    status: 'live',
+    description: 'This site — a Svelte 5 org site deployed on Vercel. A lab for experimenting with frontend design under a dark-universe theme.',
+    stack: ['Svelte 5', 'Vite', 'Vercel'],
+    url: 'https://chillpickle.org',
+    repo: 'https://github.com/quniv/chillpickle',
+  },
+  {
+    id: 'vvn-ce',
+    title: 'vvn-ce',
+    tag: 'Open Source',
+    tagColor: 'green',
+    status: 'wip',
+    description: 'Vocabulary Chrome Extension — look up, save, and review words while browsing. MV3 extension backed by a FastAPI + PostgreSQL + Redis API.',
+    stack: ['Svelte 5', 'Chrome MV3', 'FastAPI', 'PostgreSQL'],
+    url: null,
+    repo: null,
+  },
+  {
+    id: 'placeholder-1',
+    title: 'Project TBD',
+    tag: 'Internal',
+    tagColor: 'purple',
+    status: 'wip',
+    description: 'Something useful. Coming soon.',
+    stack: [],
+    url: null,
+    repo: null,
+  },
+];
+
+export const services = [
+  {
+    id: 'devops',
+    icon: '🔧',
+    title: 'Cloud & DevOps',
+    description: 'CI/CD pipelines, cloud architecture (AWS primary), container orchestration with Kubernetes, monitoring with Grafana + Prometheus. You ship faster, we keep it running.',
+    tags: ['AWS', 'Kubernetes', 'Terraform', 'CI/CD'],
+    highlight: false,
+  },
+  {
+    id: 'devsecops',
+    icon: '🛡️',
+    title: 'DevSecOps & Hardening',
+    description: 'Security baked into delivery: WAF, secrets management, SAST integration, IAM hardening, TLS automation. Small team, big threat surface — we close it.',
+    tags: ['Security', 'WAF', 'IAM', 'SAST'],
+    highlight: true,
+  },
+  {
+    id: 'ai',
+    icon: '🤖',
+    title: 'AI-Assisted Engineering',
+    description: 'Integrate AI-driven workflows into your delivery pipeline — automated troubleshooting, doc generation, operational automation. Not hype. Actual automation.',
+    tags: ['AI', 'LLM', 'Automation', 'Python'],
+    highlight: false,
+  },
+  {
+    id: 'platform',
+    icon: '🚀',
+    title: 'Platform Engineering',
+    description: 'Internal developer platforms, GitOps with ArgoCD/FluxCD, EKS cluster design, microservice scaffolding. We make your engineers move faster.',
+    tags: ['EKS', 'ArgoCD', 'GitOps', 'Platform'],
+    highlight: false,
+  },
+];
+
+export const pricing = [
+  {
+    id: 'starter',
+    label: 'Starter',
+    price: 'Contact',
+    description: 'Short-term support, one-off setup, or quick CI/CD wiring for small projects.',
+    bullets: [
+      'CI/CD pipeline setup',
+      'Basic cloud configuration',
+      'One-time infrastructure review',
+    ],
+    highlight: false,
+  },
+  {
+    id: 'retainer',
+    label: 'Retainer',
+    price: 'Contact',
+    description: 'Ongoing DevOps support — monitoring, incident response, and monthly improvements.',
+    bullets: [
+      'Monthly infrastructure maintenance',
+      'Monitoring & alerting',
+      'Priority response',
+      'Architecture reviews',
+    ],
+    highlight: true,
+  },
+  {
+    id: 'project',
+    label: 'Full Project',
+    price: 'Contact',
+    description: 'End-to-end delivery for a defined scope — architecture design through production.',
+    bullets: [
+      'Architecture & planning',
+      'Build & deploy',
+      'Handoff documentation',
+      'Post-launch support window',
+    ],
+    highlight: false,
+  },
+];
+
+export const labNotes = [
+  {
+    id: 'lab-001',
+    date: '2025-06-01',
+    type: 'lab',
+    title: 'Why We Use Infisical Over HashiCorp Vault for Small Teams',
+    excerpt: "HashiCorp Vault is powerful but operationally heavy for a 3-person team. Here's why we switched to Infisical and what we learned.",
+    tags: ['security', 'devops', 'secrets'],
+    status: 'draft',
+  },
+  {
+    id: 'lab-002',
+    date: '2025-06-04',
+    type: 'blog',
+    title: 'Building This Site: Svelte 5 and the State-Based Router Pattern',
+    excerpt: 'No router library. Just a reactive activeTab variable and conditional rendering. Here\'s how it holds up for a small org site.',
+    tags: ['svelte', 'frontend', 'architecture'],
+    status: 'draft',
+  },
+];

--- a/src/pages/Blog.svelte
+++ b/src/pages/Blog.svelte
@@ -1,0 +1,291 @@
+<!-- src/pages/Blog.svelte — Lab notes + blog feed -->
+<script>
+  import { labNotes } from '../orgData.js';
+  import { onMount } from 'svelte';
+
+  const published = labNotes.filter(n => n.status === 'published');
+
+  const pendingLines = [
+    '> [ChillPickle] Booting blog engine...',
+    '> [ChillPickle] Scanning lab notes...',
+    '> [PENDING] Lab notes — coming soon',
+    '> [PENDING] Blog posts — coming soon',
+    '> Stand by.',
+  ];
+
+  let visibleLines = [];
+  let showCursor = true;
+
+  onMount(() => {
+    if (published.length === 0) {
+      pendingLines.forEach((line, i) => {
+        setTimeout(() => {
+          visibleLines = [...visibleLines, line];
+        }, i * 600);
+      });
+    }
+
+    const id = setInterval(() => { showCursor = !showCursor; }, 530);
+    return () => clearInterval(id);
+  });
+
+  const typeLabel = { lab: 'LAB', blog: 'BLOG' };
+</script>
+
+<style>
+  /* ── Page header ── */
+  .page-header {
+    background: linear-gradient(180deg, rgba(5, 3, 20, 0.98) 0%, rgba(5, 5, 25, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.15);
+    padding: 2.5rem 2rem 2rem;
+    position: relative;
+  }
+
+  .page-header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(167, 139, 250, 0.4), transparent);
+  }
+
+  .page-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: 3px;
+    margin: 0 0 0.3rem;
+  }
+
+  .page-subtitle {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: #a78bfa;
+    letter-spacing: 2px;
+    margin: 0;
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 2.5rem 2rem;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  /* ── Terminal (pending state) ── */
+  .terminal-wrap {
+    background: rgba(5, 3, 20, 0.9);
+    border: 1px solid rgba(167, 139, 250, 0.25);
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.08);
+  }
+
+  .terminal-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.65rem 1rem;
+    background: rgba(167, 139, 250, 0.06);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.15);
+  }
+
+  .dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+  }
+
+  .dot.red    { background: #f472b6; box-shadow: 0 0 6px rgba(244, 114, 182, 0.5); }
+  .dot.yellow { background: #fbbf24; box-shadow: 0 0 6px rgba(251, 191, 36, 0.5); }
+  .dot.green  { background: #a78bfa; box-shadow: 0 0 6px rgba(167, 139, 250, 0.5); }
+
+  .terminal-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    color: #6b5a9e;
+    letter-spacing: 2px;
+    margin-left: 0.5rem;
+  }
+
+  .terminal-body {
+    padding: 1.5rem 1.5rem 1.2rem;
+    min-height: 160px;
+  }
+
+  .terminal-line {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    color: #a78bfa;
+    line-height: 1.9;
+    white-space: pre;
+  }
+
+  .terminal-line.pending {
+    color: #9d8ec4;
+  }
+
+  /* ── Published posts ── */
+  .posts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    margin-bottom: 2rem;
+  }
+
+  .post-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 1.6rem 1.8rem;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 16px rgba(167, 139, 250, 0.05);
+  }
+
+  .post-card:hover {
+    border-color: rgba(167, 139, 250, 0.4);
+    transform: translateY(-2px);
+    box-shadow: 0 0 24px rgba(167, 139, 250, 0.12);
+  }
+
+  .post-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 0.7rem;
+    flex-wrap: wrap;
+  }
+
+  .post-date {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.68rem;
+    color: #fbbf24;
+    letter-spacing: 1px;
+  }
+
+  .post-type {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.62rem;
+    letter-spacing: 1.5px;
+    padding: 0.15rem 0.5rem;
+    border-radius: 2px;
+    color: #a78bfa;
+    background: rgba(167, 139, 250, 0.08);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+  }
+
+  .post-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0 0 0.5rem;
+    letter-spacing: 0.3px;
+    line-height: 1.4;
+  }
+
+  .post-excerpt {
+    font-size: 0.86rem;
+    color: #9d8ec4;
+    line-height: 1.7;
+    margin: 0 0 0.9rem;
+  }
+
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .post-tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.62rem;
+    color: #6b5a9e;
+    background: rgba(167, 139, 250, 0.05);
+    border: 1px solid rgba(167, 139, 250, 0.12);
+    border-radius: 2px;
+    padding: 0.12rem 0.45rem;
+    letter-spacing: 0.5px;
+  }
+
+  /* ── Cursor ── */
+  .cursor-line {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    color: #4a4070;
+    padding-top: 0.8rem;
+    letter-spacing: 1px;
+  }
+
+  .cursor {
+    display: inline-block;
+    width: 8px;
+    height: 0.9em;
+    background: #a78bfa;
+    vertical-align: text-bottom;
+    margin-left: 2px;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  .cursor.visible {
+    opacity: 0.7;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 768px) {
+    main { padding: 1.5rem 1rem; }
+  }
+</style>
+
+<div class="page-header">
+  <div class="page-title">BLOG & LAB NOTES</div>
+  <div class="page-subtitle">// notes.log</div>
+</div>
+
+<main>
+  {#if published.length === 0}
+    <div class="terminal-wrap">
+      <div class="terminal-bar">
+        <div class="dot red"></div>
+        <div class="dot yellow"></div>
+        <div class="dot green"></div>
+        <span class="terminal-title">BLOG & LAB NOTES</span>
+      </div>
+      <div class="terminal-body">
+        {#each visibleLines as line, i (i)}
+          <div class="terminal-line" class:pending={line.includes('[PENDING]')}>{line}</div>
+        {/each}
+        <div class="cursor-line">
+          &nbsp;<span class="cursor" class:visible={showCursor}></span>
+        </div>
+      </div>
+    </div>
+  {:else}
+    <div class="posts-list">
+      {#each published as post (post.id)}
+        <div class="post-card">
+          <div class="post-meta">
+            <span class="post-date">{post.date}</span>
+            <span class="post-type">[{typeLabel[post.type] ?? post.type.toUpperCase()}]</span>
+          </div>
+          <h3 class="post-title">{post.title}</h3>
+          <p class="post-excerpt">{post.excerpt}</p>
+          <div class="post-tags">
+            {#each post.tags as t (t)}
+              <span class="post-tag">{t}</span>
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="cursor-line">
+      > // loading more...<span class="cursor" class:visible={showCursor}></span>
+    </div>
+  {/if}
+</main>

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -1,0 +1,257 @@
+<!-- src/pages/Home.svelte — Landing page -->
+<script>
+  import { org, missions } from '../orgData.js';
+  import TechStack from '../components/TechStack.svelte';
+  import TerminalBoot from '../components/TerminalBoot.svelte';
+
+  export let onNavigate = () => {};
+</script>
+
+<style>
+  /* ── Hero ── */
+  header.hero {
+    background: linear-gradient(180deg, rgba(5, 3, 20, 0.98) 0%, rgba(5, 5, 25, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.2);
+    padding: 5rem 2rem 4rem;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+  }
+
+  header.hero::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #a78bfa, #fbbf24, #f472b6, #a78bfa, transparent);
+    background-size: 200% 100%;
+    animation: shimmer 4s linear infinite;
+  }
+
+  @keyframes shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .org-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 4px;
+    color: #a78bfa;
+    text-shadow: 0 0 8px rgba(167, 139, 250, 0.5);
+    margin-bottom: 1.2rem;
+  }
+
+  .org-name {
+    font-size: clamp(2.4rem, 6vw, 4rem);
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: -0.5px;
+    margin-bottom: 1rem;
+    line-height: 1.1;
+  }
+
+  .org-name span {
+    color: #a78bfa;
+  }
+
+  .tagline {
+    font-size: 1.15rem;
+    color: #9d8ec4;
+    font-weight: 300;
+    letter-spacing: 0.5px;
+    max-width: 520px;
+    margin: 0 auto 2.5rem;
+    line-height: 1.7;
+  }
+
+  .cta-group {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .cta-btn {
+    display: inline-block;
+    padding: 0.65rem 1.8rem;
+    background: transparent;
+    border: none;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 500;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+    border-radius: 0;
+  }
+
+  .cta-btn.primary {
+    color: #a78bfa;
+    box-shadow: 0 0 12px rgba(167, 139, 250, 0.2), inset 0 0 0 1px rgba(167, 139, 250, 0.4);
+  }
+
+  .cta-btn.primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0 25px rgba(167, 139, 250, 0.4), inset 0 0 0 1px #a78bfa;
+    background: rgba(167, 139, 250, 0.08);
+  }
+
+  .cta-btn.secondary {
+    color: #fbbf24;
+    box-shadow: 0 0 12px rgba(251, 191, 36, 0.15), inset 0 0 0 1px rgba(251, 191, 36, 0.3);
+  }
+
+  .cta-btn.secondary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0 25px rgba(251, 191, 36, 0.3), inset 0 0 0 1px #fbbf24;
+    background: rgba(251, 191, 36, 0.06);
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 3rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .section-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 3px;
+    color: #a78bfa;
+    margin-bottom: 1.8rem;
+    text-transform: uppercase;
+  }
+
+  /* ── Mission Cards ── */
+  .missions-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+    margin-bottom: 4rem;
+  }
+
+  .mission-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 2rem 1.8rem;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.06), inset 0 0 20px rgba(167, 139, 250, 0.02);
+    transition: all 0.4s ease;
+  }
+
+  .mission-card:hover {
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.18), inset 0 0 20px rgba(167, 139, 250, 0.04);
+    transform: translateY(-4px);
+    border-color: rgba(167, 139, 250, 0.45);
+  }
+
+  .mission-icon {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .mission-card h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0 0 0.75rem;
+    letter-spacing: 0.5px;
+  }
+
+  .mission-card p {
+    font-size: 0.9rem;
+    color: #9d8ec4;
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  /* ── Stack section ── */
+  .section-stack {
+    margin-bottom: 2rem;
+  }
+
+  /* ── Footer ── */
+  footer {
+    background: rgba(5, 3, 20, 0.95);
+    backdrop-filter: blur(16px);
+    border-top: 1px solid rgba(167, 139, 250, 0.15);
+    color: #4a4070;
+    text-align: center;
+    padding: 1.8rem 2rem;
+    position: relative;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 1px;
+  }
+
+  footer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #a78bfa, #fbbf24, #f472b6, #a78bfa, transparent);
+    background-size: 200% 100%;
+    animation: shimmer 4s linear infinite;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    .missions-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 768px) {
+    header.hero {
+      padding: 4rem 1.5rem 3rem;
+    }
+
+    main {
+      padding: 2rem 1rem;
+    }
+  }
+</style>
+
+<TerminalBoot />
+
+<header class="hero">
+  <div class="org-label">// CHILLPICKLE.ORG</div>
+  <h1 class="org-name">Chill<span>Pickle</span></h1>
+  <p class="tagline">{org.tagline}</p>
+  <div class="cta-group">
+    <button class="cta-btn primary" on:click={() => onNavigate('work')}>[↗ View Work]</button>
+    <button class="cta-btn secondary" on:click={() => onNavigate('services')}>[→ Get in Touch]</button>
+  </div>
+</header>
+
+<main>
+  <div class="section-label">// MISSION</div>
+  <div class="missions-grid">
+    {#each missions as m (m.id)}
+      <div class="mission-card">
+        <div class="mission-icon">{m.icon}</div>
+        <h3>{m.title}</h3>
+        <p>{m.body}</p>
+      </div>
+    {/each}
+  </div>
+
+  <div class="section-stack">
+    <div class="section-label">// STACK</div>
+    <TechStack />
+  </div>
+</main>
+
+<footer>
+  <p>© 2025 ChillPickle · Open for work · {org.domain}</p>
+</footer>

--- a/src/pages/Services.svelte
+++ b/src/pages/Services.svelte
@@ -1,0 +1,363 @@
+<!-- src/pages/Services.svelte — Services + Pricing -->
+<script>
+  import { org, services, pricing } from '../orgData.js';
+</script>
+
+<style>
+  /* ── Page header ── */
+  .page-header {
+    background: linear-gradient(180deg, rgba(5, 3, 20, 0.98) 0%, rgba(5, 5, 25, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.15);
+    padding: 2.5rem 2rem 2rem;
+    position: relative;
+  }
+
+  .page-header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(167, 139, 250, 0.4), transparent);
+  }
+
+  .page-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: 3px;
+    margin: 0 0 0.3rem;
+  }
+
+  .page-subtitle {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: #a78bfa;
+    letter-spacing: 2px;
+    margin: 0;
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 2.5rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .section-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 3px;
+    color: #a78bfa;
+    margin-bottom: 1.6rem;
+    text-transform: uppercase;
+  }
+
+  /* ── Service cards ── */
+  .services-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.2rem;
+    margin-bottom: 3.5rem;
+  }
+
+  .service-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 1.8rem;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.06), inset 0 0 20px rgba(167, 139, 250, 0.02);
+    transition: all 0.35s ease;
+  }
+
+  .service-card:hover {
+    transform: translateY(-3px);
+    border-color: rgba(167, 139, 250, 0.4);
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.14), inset 0 0 20px rgba(167, 139, 250, 0.03);
+  }
+
+  @keyframes neonPulse {
+    0%, 100% { box-shadow: 0 0 20px rgba(167, 139, 250, 0.15), inset 0 0 20px rgba(167, 139, 250, 0.03); }
+    50%       { box-shadow: 0 0 35px rgba(167, 139, 250, 0.35), inset 0 0 25px rgba(167, 139, 250, 0.06); }
+  }
+
+  .service-card.highlight {
+    border-color: rgba(167, 139, 250, 0.5);
+    animation: neonPulse 3s ease-in-out infinite;
+  }
+
+  .service-card.highlight:hover {
+    animation: none;
+    box-shadow: 0 0 40px rgba(167, 139, 250, 0.4), inset 0 0 25px rgba(167, 139, 250, 0.06);
+  }
+
+  .service-icon {
+    font-size: 1.6rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .service-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0 0 0.6rem;
+    letter-spacing: 0.5px;
+  }
+
+  .service-desc {
+    font-size: 0.87rem;
+    color: #9d8ec4;
+    line-height: 1.7;
+    margin: 0 0 1rem;
+  }
+
+  .tags-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    color: #6b5a9e;
+    background: rgba(167, 139, 250, 0.06);
+    border: 1px solid rgba(167, 139, 250, 0.15);
+    border-radius: 2px;
+    padding: 0.15rem 0.5rem;
+    letter-spacing: 0.5px;
+  }
+
+  /* ── Pricing cards ── */
+  .pricing-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.2rem;
+    margin-bottom: 3rem;
+  }
+
+  .pricing-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 2rem 1.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    transition: all 0.35s ease;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .pricing-card:hover {
+    transform: translateY(-3px);
+    border-color: rgba(167, 139, 250, 0.4);
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.12);
+  }
+
+  @keyframes shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .pricing-card.highlight::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #a78bfa, #fbbf24, #f472b6, #a78bfa, transparent);
+    background-size: 200% 100%;
+    animation: shimmer 4s linear infinite;
+  }
+
+  .pricing-card.highlight {
+    border-color: rgba(167, 139, 250, 0.35);
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.1);
+  }
+
+  .pricing-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 3px;
+    color: #a78bfa;
+    text-transform: uppercase;
+  }
+
+  .pricing-price {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: -0.5px;
+    line-height: 1;
+  }
+
+  .pricing-desc {
+    font-size: 0.85rem;
+    color: #9d8ec4;
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .pricing-bullets {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    flex: 1;
+  }
+
+  .pricing-bullets li {
+    font-size: 0.83rem;
+    color: #7d6ea4;
+    padding-left: 1rem;
+    position: relative;
+    line-height: 1.5;
+  }
+
+  .pricing-bullets li::before {
+    content: '›';
+    position: absolute;
+    left: 0;
+    color: #a78bfa;
+  }
+
+  .contact-btn {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 1.5px;
+    padding: 0.5rem 1rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    border-radius: 0;
+    color: #a78bfa;
+    box-shadow: inset 0 0 0 1px rgba(167, 139, 250, 0.3);
+    text-decoration: none;
+    display: inline-block;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .contact-btn:hover {
+    box-shadow: inset 0 0 0 1px #a78bfa, 0 0 12px rgba(167, 139, 250, 0.2);
+    background: rgba(167, 139, 250, 0.07);
+  }
+
+  /* ── Contact strip ── */
+  .contact-strip {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 2.5rem 2rem;
+    text-align: center;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.06);
+    margin-bottom: 2rem;
+  }
+
+  .contact-strip h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0 0 0.7rem;
+    letter-spacing: 0.5px;
+  }
+
+  .contact-strip p {
+    font-size: 0.88rem;
+    color: #9d8ec4;
+    margin: 0 0 1.2rem;
+    line-height: 1.6;
+  }
+
+  .email-link {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    color: #a78bfa;
+    text-decoration: none;
+    letter-spacing: 1px;
+    transition: all 0.2s;
+  }
+
+  .email-link:hover {
+    color: #f0ecff;
+    text-shadow: 0 0 8px rgba(167, 139, 250, 0.5);
+  }
+
+  .philosophy-note {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    color: #4a4070;
+    letter-spacing: 2px;
+    margin: 0.8rem 0 0;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    .services-grid  { grid-template-columns: 1fr; }
+    .pricing-grid   { grid-template-columns: 1fr; }
+  }
+
+  @media (max-width: 768px) {
+    main { padding: 1.5rem 1rem; }
+  }
+</style>
+
+<div class="page-header">
+  <div class="page-title">SERVICES / PRICING</div>
+  <div class="page-subtitle">// what we do</div>
+</div>
+
+<main>
+  <div class="section-label">// WHAT WE DO</div>
+  <div class="services-grid">
+    {#each services as s (s.id)}
+      <div class="service-card" class:highlight={s.highlight}>
+        <div class="service-icon">{s.icon}</div>
+        <h3 class="service-title">{s.title}</h3>
+        <p class="service-desc">{s.description}</p>
+        <div class="tags-row">
+          {#each s.tags as t (t)}
+            <span class="tag">{t}</span>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="section-label">// PRICING</div>
+  <div class="pricing-grid">
+    {#each pricing as p (p.id)}
+      <div class="pricing-card" class:highlight={p.highlight}>
+        <div class="pricing-label">{p.label}</div>
+        <div class="pricing-price">{p.price}</div>
+        <p class="pricing-desc">{p.description}</p>
+        <ul class="pricing-bullets">
+          {#each p.bullets as b, bi (bi)}
+            <li>{b}</li>
+          {/each}
+        </ul>
+        <a class="contact-btn" href="mailto:{org.email}">[→ Contact]</a>
+      </div>
+    {/each}
+  </div>
+
+  <div class="contact-strip">
+    <h3>Ready to build something?</h3>
+    <p>Tell us what you're trying to solve. We'll figure out if we're the right fit.</p>
+    <a class="email-link" href="mailto:{org.email}">{org.email}</a>
+    <p class="philosophy-note">reputation-based · affordable · ships</p>
+  </div>
+</main>

--- a/src/pages/Team.svelte
+++ b/src/pages/Team.svelte
@@ -1,0 +1,267 @@
+<!-- src/pages/Team.svelte — Team member cards -->
+<script>
+  import { team } from '../orgData.js';
+  import GameOfLife from '../components/GameOfLife.svelte';
+
+  const SLOTS = 4;
+  const emptySlotIndices = Array.from({ length: SLOTS - team.length }, (_, i) => i);
+</script>
+
+<style>
+  /* ── Page header ── */
+  .page-header {
+    background: linear-gradient(180deg, rgba(5, 3, 20, 0.98) 0%, rgba(5, 5, 25, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.15);
+    padding: 2.5rem 2rem 2rem;
+    position: relative;
+  }
+
+  .page-header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(167, 139, 250, 0.4), transparent);
+  }
+
+  .page-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: 3px;
+    margin: 0 0 0.3rem;
+  }
+
+  .page-subtitle {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: #a78bfa;
+    letter-spacing: 2px;
+    margin: 0;
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 2.5rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .section-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 3px;
+    color: #a78bfa;
+    margin-bottom: 1.6rem;
+    text-transform: uppercase;
+  }
+
+  /* ── Mission strip ── */
+  .mission-strip {
+    font-style: italic;
+    font-size: 0.95rem;
+    color: #9d8ec4;
+    letter-spacing: 0.5px;
+    margin-bottom: 2.5rem;
+    line-height: 1.7;
+  }
+
+  /* ── Team grid ── */
+  .team-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.2rem;
+    margin-bottom: 3.5rem;
+  }
+
+  /* ── Member card ── */
+  .member-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.25);
+    border-radius: 4px;
+    padding: 2rem 1.5rem;
+    text-align: center;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.08), inset 0 0 20px rgba(167, 139, 250, 0.02);
+    transition: all 0.4s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .member-card:hover {
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.2), inset 0 0 20px rgba(167, 139, 250, 0.04);
+    transform: translateY(-4px);
+    border-color: rgba(167, 139, 250, 0.5);
+  }
+
+  .member-avatar {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+    border: 2px solid rgba(167, 139, 250, 0.4);
+    margin-bottom: 0.4rem;
+    transition: all 0.4s ease;
+    box-shadow: 0 0 16px rgba(167, 139, 250, 0.15);
+    object-fit: cover;
+  }
+
+  .member-card:hover .member-avatar {
+    border-color: #a78bfa;
+    box-shadow: 0 0 24px rgba(167, 139, 250, 0.35);
+  }
+
+  .member-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0;
+    letter-spacing: 0.5px;
+  }
+
+  .member-role {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.68rem;
+    color: #a78bfa;
+    letter-spacing: 1.5px;
+    text-shadow: 0 0 6px rgba(167, 139, 250, 0.4);
+  }
+
+  .member-bio {
+    font-size: 0.8rem;
+    color: #7d6ea4;
+    line-height: 1.6;
+    margin: 0.3rem 0 0;
+    text-align: left;
+  }
+
+  .skills-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    justify-content: center;
+    margin-top: 0.2rem;
+  }
+
+  .skill-chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    color: #6b5a9e;
+    background: rgba(167, 139, 250, 0.06);
+    border: 1px solid rgba(167, 139, 250, 0.15);
+    border-radius: 2px;
+    padding: 0.15rem 0.45rem;
+    letter-spacing: 0.5px;
+  }
+
+  .member-links {
+    display: flex;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+  }
+
+  .member-link {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.68rem;
+    color: #9d8ec4;
+    text-decoration: none;
+    letter-spacing: 1px;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 2px;
+    transition: all 0.2s;
+  }
+
+  .member-link:hover {
+    color: #a78bfa;
+    border-color: rgba(167, 139, 250, 0.5);
+    background: rgba(167, 139, 250, 0.06);
+  }
+
+  /* ── Empty slot card ── */
+  .slot-empty {
+    background: rgba(5, 3, 20, 0.4);
+    border: 1px dashed rgba(167, 139, 250, 0.15);
+    border-radius: 4px;
+    padding: 2rem 1.5rem;
+    text-align: center;
+    opacity: 0.5;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 160px;
+  }
+
+  .slot-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: #4a4070;
+    letter-spacing: 2px;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 1000px) {
+    .team-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 600px) {
+    .team-grid {
+      grid-template-columns: 1fr;
+    }
+
+    main { padding: 1.5rem 1rem; }
+  }
+</style>
+
+<div class="page-header">
+  <div class="page-title">TEAM</div>
+  <div class="page-subtitle">// who we are</div>
+</div>
+
+<main>
+  <div class="section-label">// PEOPLE</div>
+  <p class="mission-strip">A small group of engineers who build things that actually work.</p>
+
+  <div class="team-grid">
+    {#each team as m (m.id)}
+      <div class="member-card">
+        <img class="member-avatar" src={m.avatar} alt={m.name} />
+        <h3 class="member-name">{m.name}</h3>
+        <div class="member-role">{m.role}</div>
+        <p class="member-bio">{m.bio}</p>
+        <div class="skills-row">
+          {#each m.skills as s (s)}
+            <span class="skill-chip">{s}</span>
+          {/each}
+        </div>
+        <div class="member-links">
+          {#if m.links.github}
+            <a class="member-link" href={m.links.github} target="_blank" rel="noopener noreferrer">GitHub</a>
+          {/if}
+          {#if m.links.linkedin}
+            <a class="member-link" href={m.links.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+          {/if}
+        </div>
+      </div>
+    {/each}
+
+    {#each emptySlotIndices as idx (idx)}
+      <div class="slot-empty">
+        <div class="slot-label">+ TBD</div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="section-label">// HOW WE WORK</div>
+  <GameOfLife />
+</main>

--- a/src/pages/Work.svelte
+++ b/src/pages/Work.svelte
@@ -1,0 +1,271 @@
+<!-- src/pages/Work.svelte — Projects showcase -->
+<script>
+  import { projects } from '../orgData.js';
+  import { onMount } from 'svelte';
+
+  let showCursor = true;
+  onMount(() => {
+    const id = setInterval(() => { showCursor = !showCursor; }, 530);
+    return () => clearInterval(id);
+  });
+</script>
+
+<style>
+  /* ── Page header ── */
+  .page-header {
+    background: linear-gradient(180deg, rgba(5, 3, 20, 0.98) 0%, rgba(5, 5, 25, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(167, 139, 250, 0.15);
+    padding: 2.5rem 2rem 2rem;
+    position: relative;
+  }
+
+  .page-header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(167, 139, 250, 0.4), transparent);
+  }
+
+  .page-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #f0ecff;
+    letter-spacing: 3px;
+    margin: 0 0 0.3rem;
+  }
+
+  .page-subtitle {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: #a78bfa;
+    letter-spacing: 2px;
+    margin: 0;
+  }
+
+  /* ── Main ── */
+  main {
+    padding: 2.5rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  /* ── Project cards ── */
+  .projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 3rem;
+  }
+
+  .project-card {
+    background: rgba(5, 3, 20, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+    border-radius: 4px;
+    padding: 1.8rem;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.06), inset 0 0 20px rgba(167, 139, 250, 0.02);
+    transition: all 0.35s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+  }
+
+  .project-card:hover {
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.16), inset 0 0 20px rgba(167, 139, 250, 0.03);
+    transform: translateY(-3px);
+    border-color: rgba(167, 139, 250, 0.4);
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .project-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f0ecff;
+    margin: 0;
+    letter-spacing: 0.5px;
+    flex: 1;
+  }
+
+  .status-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    letter-spacing: 1.5px;
+    padding: 0.2rem 0.55rem;
+    border-radius: 2px;
+    text-transform: uppercase;
+    flex-shrink: 0;
+  }
+
+  .status-badge.live {
+    color: #00ff78;
+    background: rgba(0, 255, 120, 0.08);
+    border: 1px solid rgba(0, 255, 120, 0.3);
+    box-shadow: 0 0 8px rgba(0, 255, 120, 0.15);
+  }
+
+  .status-badge.wip {
+    color: #fbbf24;
+    background: rgba(251, 191, 36, 0.08);
+    border: 1px solid rgba(251, 191, 36, 0.3);
+  }
+
+  .tag-chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    letter-spacing: 1px;
+    padding: 0.2rem 0.55rem;
+    border-radius: 2px;
+    text-transform: uppercase;
+  }
+
+  .tag-chip.green {
+    color: #00ff78;
+    background: rgba(0, 255, 120, 0.06);
+    border: 1px solid rgba(0, 255, 120, 0.2);
+  }
+
+  .tag-chip.purple {
+    color: #a78bfa;
+    background: rgba(167, 139, 250, 0.06);
+    border: 1px solid rgba(167, 139, 250, 0.2);
+  }
+
+  .project-desc {
+    font-size: 0.88rem;
+    color: #9d8ec4;
+    line-height: 1.7;
+    margin: 0;
+    flex: 1;
+  }
+
+  .stack-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .stack-chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    color: #6b5a9e;
+    background: rgba(167, 139, 250, 0.05);
+    border: 1px solid rgba(167, 139, 250, 0.12);
+    border-radius: 2px;
+    padding: 0.15rem 0.5rem;
+    letter-spacing: 0.5px;
+  }
+
+  .card-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .card-link {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 1.5px;
+    padding: 0.35rem 0.9rem;
+    background: transparent;
+    border: none;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    border-radius: 0;
+    color: #a78bfa;
+    box-shadow: inset 0 0 0 1px rgba(167, 139, 250, 0.3);
+  }
+
+  .card-link:hover {
+    box-shadow: inset 0 0 0 1px #a78bfa, 0 0 12px rgba(167, 139, 250, 0.2);
+    background: rgba(167, 139, 250, 0.07);
+  }
+
+  /* ── Terminal footer ── */
+  .terminal-footer {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: #4a4070;
+    letter-spacing: 1px;
+    padding: 1rem 0;
+    border-top: 1px solid rgba(167, 139, 250, 0.1);
+  }
+
+  .cursor {
+    display: inline-block;
+    width: 8px;
+    height: 0.9em;
+    background: #a78bfa;
+    vertical-align: text-bottom;
+    margin-left: 2px;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  .cursor.visible {
+    opacity: 0.7;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 768px) {
+    main { padding: 1.5rem 1rem; }
+    .projects-grid { grid-template-columns: 1fr; }
+  }
+</style>
+
+<div class="page-header">
+  <div class="page-title">WORK / PROJECTS</div>
+  <div class="page-subtitle">// projects.log</div>
+</div>
+
+<main>
+  <div class="projects-grid">
+    {#each projects as p (p.id)}
+      <div class="project-card">
+        <div class="card-header">
+          <h3 class="project-title">{p.title}</h3>
+          <span class="status-badge {p.status}">{p.status === 'live' ? '● live' : '○ wip'}</span>
+          <span class="tag-chip {p.tagColor}">{p.tag}</span>
+        </div>
+
+        <p class="project-desc">{p.description}</p>
+
+        {#if p.stack.length > 0}
+          <div class="stack-row">
+            {#each p.stack as s (s)}
+              <span class="stack-chip">{s}</span>
+            {/each}
+          </div>
+        {/if}
+
+        {#if p.url || p.repo}
+          <div class="card-links">
+            {#if p.url}
+              <a class="card-link" href={p.url} target="_blank" rel="noopener noreferrer">↗ Live</a>
+            {/if}
+            {#if p.repo}
+              <a class="card-link" href={p.repo} target="_blank" rel="noopener noreferrer">⌥ Repo</a>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <div class="terminal-footer">
+    > // more projects loading...<span class="cursor" class:visible={showCursor}></span>
+  </div>
+</main>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "(?<sub>.+)\\.dev\\.chillpickle\\.org" }],
+      "destination": "/cv/QuyetDoan_DevOps_Jan2026.pdf",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Transform personal portfolio into a 5-page org site for ChillPickle
- Add `src/orgData.js` as central content source (missions, team, projects, services, pricing, lab notes)
- New pages: Home (hero + missions + TechStack), Work (project cards), Services (service + pricing cards), Team (member cards + 3 TBD slots), Blog & Lab Notes (terminal placeholder until posts publish)
- Update Sidebar to 5-tab nav; retire personal AboutMe/News pages from routing
- Fix broken CV download path (`/qitpy/cv/` → `/cv/`)
- Add `vercel.json` for `*.dev.chillpickle.org` → CV PDF redirect
- Add `CLAUDE.md` with project architecture guidance
- Add `.gitleaks.toml` to allowlist a 2024 expired pre-signed S3 URL in git history

## Test plan

- [ ] `npm run build` — zero errors, zero warnings
- [ ] `npm run lint` — clean
- [ ] Dev server: all 5 tabs load without JS console errors
- [ ] Home CTA buttons navigate to Work and Services tabs
- [ ] TerminalBoot overlay shows `[ChillPickle]` boot lines
- [ ] Team page: 1 real member card + 3 dashed TBD placeholder slots
- [ ] Blog page: shows terminal pending state (no published posts)
- [ ] `chillpickle.org/cv/download/` redirects to the PDF correctly