### PR TITLE
feat: rebrand favicon to dark Q

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y=".9em" font-size="90">🥒</text>
+  <rect width="100" height="100" rx="18" fill="#030308"/>
+  <text
+    x="50"
+    y="74"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="72"
+    font-weight="700"
+    fill="#ffffff"
+    text-anchor="middle"
+    letter-spacing="-2"
+  >Q</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replaces the pickle emoji favicon (`public/favicon.svg`) with a clean dark-themed SVG: rounded-square `#030308` background with a bold white serif **Q**, matching the site's dark aesthetic
- Site title already updated to `Technology Innovation Labs — qtlab.dev` in main; no title changes in this PR

## Test plan
- [ ] Verify favicon shows as dark "Q" in browser tab
- [ ] Confirm CI passes (build + lint)