### PR TITLE
WEG-4: move News next to Home

### DIFF
--- a/src/components/TopNav.svelte
+++ b/src/components/TopNav.svelte
@@ -6,11 +6,11 @@
 
   const tabs = [
     { id: 'home',     label: 'Home' },
+    { id: 'news',     label: 'News' },
     { id: 'work',     label: 'Work' },
     { id: 'services', label: 'Services' },
     { id: 'team',     label: 'Team' },
     { id: 'blog',     label: 'Blog' },
-    { id: 'news',     label: 'News' },
   ];
 
   function select(id) {


### PR DESCRIPTION
Closes WEG-4

## Summary
- place News immediately after Home in the shared navigation tab order
- apply the order consistently to desktop and mobile navigation

## Verification
- npm run lint (0 errors; 4 existing warnings in News.svelte)
- npm run build