### PR TITLE
feat: link qtlab experience to website

### DIFF
--- a/src/pages/member/quniv/CV.svelte
+++ b/src/pages/member/quniv/CV.svelte
@@ -59,7 +59,13 @@
           <header class="entry-header">
             <div>
               <h3>{job.title}</h3>
-              <p class="company">{job.company}</p>
+              <p class="company">
+                {#if job.companyUrl}
+                  <a href={job.companyUrl} target="_blank" rel="noopener noreferrer">{job.company}</a>
+                {:else}
+                  {job.company}
+                {/if}
+              </p>
             </div>
             <p class="period">{job.period}</p>
           </header>
@@ -85,7 +91,13 @@
         <header class="entry-header">
           <div>
             <h3>{project.title}</h3>
-            <p class="company">{project.company}</p>
+            <p class="company">
+              {#if project.companyUrl}
+                <a href={project.companyUrl} target="_blank" rel="noopener noreferrer">{project.company}</a>
+              {:else}
+                {project.company}
+              {/if}
+            </p>
           </div>
           <p class="period">{project.period}</p>
         </header>
@@ -297,6 +309,11 @@
     color: #1267f4;
     font-size: 8.8pt;
     font-weight: 700;
+  }
+
+  .company a {
+    color: inherit;
+    text-decoration: none;
   }
 
   .company::before {

--- a/src/pages/member/quniv/Profile.svelte
+++ b/src/pages/member/quniv/Profile.svelte
@@ -168,7 +168,13 @@
             <div class="job-header">
               <div>
                 <h3>{job.title}</h3>
-                <p class="company">{job.company}</p>
+                <p class="company">
+                  {#if job.companyUrl}
+                    <a class="company-link" href={job.companyUrl} target="_blank" rel="noopener noreferrer">{job.company}</a>
+                  {:else}
+                    {job.company}
+                  {/if}
+                </p>
               </div>
               <p class="period">{job.period}</p>
             </div>
@@ -493,6 +499,19 @@
     color: var(--muted) !important;
     font-family: 'JetBrains Mono', monospace;
     font-size: 0.7rem !important;
+  }
+
+  .company-link {
+    color: inherit;
+    text-decoration-color: var(--rule);
+    text-underline-offset: 0.2em;
+    transition: color 160ms ease, text-decoration-color 160ms ease;
+  }
+
+  .company-link:hover,
+  .company-link:focus-visible {
+    color: var(--primary);
+    text-decoration-color: currentColor;
   }
 
   .job-description {

--- a/src/pages/member/quniv/cvData.js
+++ b/src/pages/member/quniv/cvData.js
@@ -42,6 +42,7 @@ export const cvData = {
       id: 'qtlab',
       title: 'AI-Augmented Engineering Lab',
       company: 'qtlab.dev',
+      companyUrl: 'https://qtlab.dev/',
       period: 'May 2026 – Present',
       description: 'Self-learning and development with AI-assisted workflows, Deep dive into agents and multi-agents systems capabilities.',
       stacks: ['AI Agents', 'Multica', 'Hermes Agent', 'OpenClaw', 'OpenRouter', 'Codex', 'Claude Code', 'Kubernetes', 'Argo CD', 'Cilium', 'Terraform', 'Infisical', 'Svelte', 'FastAPI', 'PostgreSQL', 'Redis'],


### PR DESCRIPTION
## Summary
- add the qtlab.dev company URL to the AI-Augmented Engineering Lab experience data
- render the company name as a secure external link on the member profile
- preserve the same clickable company link in the generated CV

## Validation
- bun run build
- bun run lint (0 errors; 4 existing security warnings in src/pages/News.svelte)
- Svelte autofixer on Profile.svelte and CV.svelte with no reported issues
- git diff --check
- Gitleaks commit and push hooks passed

## Impact
Visitors and CV readers can open https://qtlab.dev/ directly from the AI-Augmented Engineering Lab entry. Other experience company names remain plain text unless they define their own company URL.